### PR TITLE
Fixed content tagging call

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -189,10 +189,14 @@ func AssignTagToContentHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	contentID := vars["content-uuid"]
 	tag := vars["tag"]
-	appID := vars["app-uuid"]
 
-	err := TagContent(contentID, tag, appID)
+	appID, err := fromContext("AppID", r)
 	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := TagContent(contentID, tag, appID); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Updated `AssignTagToContent` handler so that it pulls the app ID from the request context rather than the request itself, because the app ID doesn't get passed to this endpoint.